### PR TITLE
Fixed HUD aspect ratio on mobile devices

### DIFF
--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -94,7 +94,9 @@ var MyGame = tpf.Game.extend({
 	setGame: function() {
 		this.menu = null;
 		this.dead = false;
-		this.hud = new MyHud( 640, 480 );
+
+		var hudWidth = 640;
+        	this.hud = new MyHud( hudWidth, height / width * hudWidth );
 
 		this.blobKillCount = 0;
 		this.blobSpawnWaitInitial = this.blobSpawnWaitInitial;


### PR DESCRIPTION
The HUD size was hard-coded to 640x480, which causes it to look stretched on iPhone (especially noticeable with the grenade launcher), which has a different aspect ratio (see screenshot):

![simulator screen shot 30 may 2016 15 19 00](https://cloud.githubusercontent.com/assets/546885/15652235/ac8b1ffa-267c-11e6-8f8f-079f3b2fb843.png)

I originally tried just using the canvas width/height instead of a hard-coded value, which fixes the problem on iPhone, but causes the grenade launcher to look too small on an iPad relative to the size of the grenades:

![simulator screen shot 30 may 2016 15 20 35](https://cloud.githubusercontent.com/assets/546885/15652248/c579fd88-267c-11e6-9e94-5a6c386a7a47.png)

So instead, I've kept 640 for the width, but set the height proportional to the canvas size. This means that the HUD always maintains the same scale relative to the screen width (and the grenades that it fires), but doesn't get distorted for screens with different aspect ratios:

![simulator screen shot 30 may 2016 15 21 46](https://cloud.githubusercontent.com/assets/546885/15652308/36aebaac-267d-11e6-9937-a585f722db1d.png)

![simulator screen shot 30 may 2016 15 42 44](https://cloud.githubusercontent.com/assets/546885/15652309/3cf030da-267d-11e6-90fd-eadbe4892fad.png)
