### PR TITLE
Fix misalignment of grenade projectile sprite after recycling

### DIFF
--- a/lib/game/weapons/grenade-launcher.js
+++ b/lib/game/weapons/grenade-launcher.js
@@ -87,7 +87,7 @@ EntityGrenade = tpf.Entity.extend({
 	},
 	
 	reset: function( x, y, settings ) {
-		this.parent(x,y,settings);
+		this.parent( x-this.size.x/2, y-this.size.y/2, settings ); // center on spawn pos
 		this.vel.x = -Math.sin(this.angle) * this.speed;
 		this.vel.y = -Math.cos(this.angle) * this.speed;
 		this.vel.z = 1.2;


### PR DESCRIPTION
After a grenade entity was recycled from the EntityPool, the offset compensation for the sprite size wasn't being applied, with the result that the sprite was offset to the right with respect the barrel of the grenade launcher.

This fix applies the same offset when resetting a recycled grenade as is applied when it's first created.

Note: It would be more robust if there was a way to share the setup code between the init and reset functions, since they are mostly identical, but I'm not sure how best to do that given the need to call this.parent().
